### PR TITLE
SpacetimeDBURI argument in place of host and ssl enabled bool

### DIFF
--- a/examples/quickstart/client/Program.cs
+++ b/examples/quickstart/client/Program.cs
@@ -133,13 +133,12 @@ void OnSubscriptionApplied()
     PrintMessagesInOrder();
 }
 
-const string HOST = "localhost:3000";
-const string DBNAME = "chat2";
-const bool SSL_ENABLED = false;
+const string HOST = "http://localhost:3000";
+const string DBNAME = "chatqs";
 
 void ProcessThread()
 {
-    SpacetimeDBClient.instance.Connect(AuthToken.Token, HOST, DBNAME, SSL_ENABLED);
+    SpacetimeDBClient.instance.Connect(AuthToken.Token, HOST, DBNAME);
 
     // loop until cancellation token
     while (!cancel_token.IsCancellationRequested)

--- a/examples/quickstart/client/module_bindings/Message.cs
+++ b/examples/quickstart/client/module_bindings/Message.cs
@@ -107,11 +107,9 @@ namespace SpacetimeDB.Types
 		}
 
 		public delegate void InsertEventHandler(Message insertedValue, SpacetimeDB.Types.ReducerEvent dbEvent);
-		public delegate void UpdateEventHandler(Message oldValue, Message newValue, SpacetimeDB.Types.ReducerEvent dbEvent);
 		public delegate void DeleteEventHandler(Message deletedValue, SpacetimeDB.Types.ReducerEvent dbEvent);
 		public delegate void RowUpdateEventHandler(SpacetimeDBClient.TableOp op, Message oldValue, Message newValue, SpacetimeDB.Types.ReducerEvent dbEvent);
 		public static event InsertEventHandler OnInsert;
-		public static event UpdateEventHandler OnUpdate;
 		public static event DeleteEventHandler OnBeforeDelete;
 		public static event DeleteEventHandler OnDelete;
 		public static event RowUpdateEventHandler OnRowUpdate;
@@ -119,11 +117,6 @@ namespace SpacetimeDB.Types
 		public static void OnInsertEvent(object newValue, ClientApi.Event dbEvent)
 		{
 			OnInsert?.Invoke((Message)newValue,(ReducerEvent)dbEvent?.FunctionCall.CallInfo);
-		}
-
-		public static void OnUpdateEvent(object oldValue, object newValue, ClientApi.Event dbEvent)
-		{
-			OnUpdate?.Invoke((Message)oldValue,(Message)newValue,(ReducerEvent)dbEvent?.FunctionCall.CallInfo);
 		}
 
 		public static void OnBeforeDeleteEvent(object oldValue, ClientApi.Event dbEvent)

--- a/examples/quickstart/client/module_bindings/User.cs
+++ b/examples/quickstart/client/module_bindings/User.cs
@@ -100,6 +100,16 @@ namespace SpacetimeDB.Types
 			return SpacetimeDB.SATS.AlgebraicValue.Compare(t.product.elements[0].algebraicType, primaryColumnValue1, primaryColumnValue2);
 		}
 
+		public static SpacetimeDB.SATS.AlgebraicValue GetPrimaryKeyValue(SpacetimeDB.SATS.AlgebraicValue v)
+		{
+			return v.AsProductValue().elements[0];
+		}
+
+		public static SpacetimeDB.SATS.AlgebraicType GetPrimaryKeyType(SpacetimeDB.SATS.AlgebraicType t)
+		{
+			return t.product.elements[0].algebraicType;
+		}
+
 		public delegate void InsertEventHandler(User insertedValue, SpacetimeDB.Types.ReducerEvent dbEvent);
 		public delegate void UpdateEventHandler(User oldValue, User newValue, SpacetimeDB.Types.ReducerEvent dbEvent);
 		public delegate void DeleteEventHandler(User deletedValue, SpacetimeDB.Types.ReducerEvent dbEvent);

--- a/examples/quickstart/server/Cargo.lock
+++ b/examples/quickstart/server/Cargo.lock
@@ -3,10 +3,28 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "approx"
@@ -30,6 +48,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +70,21 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
@@ -106,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,12 +208,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "memchr"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -185,6 +263,12 @@ checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "scoped-tls"
@@ -213,7 +297,9 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "0.5.0"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2607c4aeda83c3568a5e371bc0a1caa0aa104732987814358bb7e062cf6ccf"
 dependencies = [
  "log",
  "once_cell",
@@ -225,7 +311,9 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "0.5.0"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6a9b4b143d79933f5e7f00d074ebc391d4f152ae2dd56be6beb1755532d7f6"
 dependencies = [
  "humantime",
  "proc-macro2",
@@ -235,11 +323,15 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "0.5.0"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6448feac3c8eea403c8cb1cf315958aec4e57c713c002ea8b9064fab9fea9fd9"
 
 [[package]]
 name = "spacetimedb-lib"
-version = "0.5.0"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8297e4e5843d346bd7844366e3cdf3b1dfd9259b466166d4e9c8588106b967b5"
 dependencies = [
  "anyhow",
  "enum-as-inner",
@@ -253,7 +345,9 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "0.5.0"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d414893befd6b19e874243334cb5709348aedc7eae01db7813b17f10583ab8"
 dependencies = [
  "arrayvec",
  "decorum",

--- a/examples/quickstart/server/Cargo.toml
+++ b/examples/quickstart/server/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "0.6"
+spacetimedb = "0.7"
 log = "0.4"
 anyhow = "1.0"

--- a/examples/quickstart/server/Cargo.toml
+++ b/examples/quickstart/server/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { path = "../../../../spacetimedb/crates/bindings" }
+spacetimedb = "0.6"
 log = "0.4"
 anyhow = "1.0"

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -447,25 +447,25 @@ namespace SpacetimeDB
         /// <summary>
         /// Connect to a remote spacetime instance.
         /// </summary>
-        /// <param name="spacetimeDbURI"> URI of the SpacetimeDB server (ex: https://testnet.spacetimedb.com)
+        /// <param name="uri"> URI of the SpacetimeDB server (ex: https://testnet.spacetimedb.com)
         /// <param name="addressOrName">The name or address of the database to connect to</param>
-        public void Connect(string token, string spacetimeDbURI, string addressOrName)
+        public void Connect(string token, string uri, string addressOrName)
         {
             isClosing = false;
 
-            spacetimeDbURI = spacetimeDbURI.Replace("http://", "ws://");
-            spacetimeDbURI = spacetimeDbURI.Replace("https://", "wss://");
-            if (!spacetimeDbURI.StartsWith("ws://") && !spacetimeDbURI.StartsWith("wss://"))
+            uri = uri.Replace("http://", "ws://");
+            uri = uri.Replace("https://", "wss://");
+            if (!uri.StartsWith("ws://") && !uri.StartsWith("wss://"))
             {
-                spacetimeDbURI = $"ws://{spacetimeDbURI}";
+                uri = $"ws://{uri}";
             }
 
-            logger.Log($"SpacetimeDBClient: Connecting to {spacetimeDbURI} {addressOrName}");
+            logger.Log($"SpacetimeDBClient: Connecting to {uri} {addressOrName}");
             Task.Run(async () =>
             {
                 try
                 {
-                    await webSocket.Connect(token, spacetimeDbURI, addressOrName);
+                    await webSocket.Connect(token, uri, addressOrName);
                 }
                 catch (Exception e)
                 {

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -447,19 +447,25 @@ namespace SpacetimeDB
         /// <summary>
         /// Connect to a remote spacetime instance.
         /// </summary>
-        /// <param name="host">The host or IP address and the port to connect to. Example: spacetime.spacetimedb.net:3000</param>
+        /// <param name="spacetimeDbURI"> URI of the SpacetimeDB server (ex: https://testnet.spacetimedb.com)
         /// <param name="addressOrName">The name or address of the database to connect to</param>
-        /// <param name="sslEnabled">Should websocket use SSL</param>
-        public void Connect(string token, string host, string addressOrName, bool sslEnabled = true)
+        public void Connect(string token, string spacetimeDbURI, string addressOrName)
         {
             isClosing = false;
 
-            logger.Log($"SpacetimeDBClient: Connecting to {host} {addressOrName}");
+            spacetimeDbURI = spacetimeDbURI.Replace("http://", "ws://");
+            spacetimeDbURI = spacetimeDbURI.Replace("https://", "wss://");
+            if (!spacetimeDbURI.StartsWith("ws://") && !spacetimeDbURI.StartsWith("wss://"))
+            {
+                spacetimeDbURI = $"ws://{spacetimeDbURI}";
+            }
+
+            logger.Log($"SpacetimeDBClient: Connecting to {spacetimeDbURI} {addressOrName}");
             Task.Run(async () =>
             {
                 try
                 {
-                    await webSocket.Connect(token, host, addressOrName, sslEnabled);
+                    await webSocket.Connect(token, spacetimeDbURI, addressOrName);
                 }
                 catch (Exception e)
                 {

--- a/src/WebSocket.cs
+++ b/src/WebSocket.cs
@@ -145,10 +145,9 @@ class OnSendErrorMessage : MainThreadDispatch
 
         public bool IsConnected { get { return Ws != null && Ws.State == WebSocketState.Open; } }
 
-        public async Task Connect(string auth, string host, string nameOrAddress, bool sslEnabled)
+        public async Task Connect(string auth, string spacetimeDbURI, string nameOrAddress)
         {
-            var protocol = sslEnabled ? "wss" : "ws";
-            var url = new Uri($"{protocol}://{host}/database/subscribe/{nameOrAddress}");
+            var url = new Uri($"{spacetimeDbURI}/database/subscribe/{nameOrAddress}");
             Ws.Options.AddSubProtocol(_options.Protocol);
 
             var source = new CancellationTokenSource(10000);

--- a/src/WebSocket.cs
+++ b/src/WebSocket.cs
@@ -145,9 +145,9 @@ class OnSendErrorMessage : MainThreadDispatch
 
         public bool IsConnected { get { return Ws != null && Ws.State == WebSocketState.Open; } }
 
-        public async Task Connect(string auth, string spacetimeDbURI, string nameOrAddress)
+        public async Task Connect(string auth, string uri, string nameOrAddress)
         {
-            var url = new Uri($"{spacetimeDbURI}/database/subscribe/{nameOrAddress}");
+            var url = new Uri($"{uri}/database/subscribe/{nameOrAddress}");
             Ws.Options.AddSubProtocol(_options.Protocol);
 
             var source = new CancellationTokenSource(10000);


### PR DESCRIPTION
## Description of Changes
To make the SDKs more consistent, we are moving towards including the protocol in the spacetimedb_uri parameter to the connect function instead of providing a host and a bool for sslenabled

## API

 - [X] This is an API breaking change to the SDK

The connect function call for existing projects need to be updated to remove the SSLEnabled argument and include the protocol in the spacetimedb_uri parameter


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
