### PR TITLE
Added new callback - onBeforeSubscriptionApplied

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -637,7 +637,7 @@ namespace SpacetimeDB
         {
             switch (message.TypeCase)
             {
-                case Message.TypeOneofCase.Subscribe:
+                case Message.TypeOneofCase.SubscriptionUpdate:
                     onBeforeSubscriptionApplied?.Invoke();
                     break;
             }

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -79,6 +79,11 @@ namespace SpacetimeDB
         public event RowUpdate onRowUpdate;
 
         /// <summary>
+        /// Invoked when a subscription is about to start being processed. This is called even before OnBeforeDelete.
+        /// </summary>
+        public event Action onBeforeSubscriptionApplied;
+        
+        /// <summary>
         /// Invoked when the local client cache is updated as a result of changes made to the subscription queries.
         /// </summary>
         public event Action onSubscriptionApplied;
@@ -630,6 +635,13 @@ namespace SpacetimeDB
 
         private void OnMessageProcessComplete(Message message, List<DbOp> dbOps)
         {
+            switch (message.TypeCase)
+            {
+                case Message.TypeOneofCase.Subscribe:
+                    onBeforeSubscriptionApplied?.Invoke();
+                    break;
+            }
+            
             switch (message.TypeCase)
             {
                 case Message.TypeOneofCase.SubscriptionUpdate:


### PR DESCRIPTION
## Description of Changes
*Describe what has been changed, any new features or bug fixes*

- Added new callback `onBeforeSubscriptionApplied`. This is invoked when a subscription update message has been received and is going to be applied. This callback is invoked before all other callbacks, including `OnBeforeDelete(...)`.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

- None
