### PR TITLE
Nit: remove unused `inserts` field

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -518,7 +518,6 @@ namespace SpacetimeDB
         {
             public Message message;
             public List<DbOp> dbOps;
-            public HashSet<byte[]> inserts;
         }
 
         // The message that has been preprocessed and has had its state diff calculated


### PR DESCRIPTION
## Description of Changes

This field was flagged as unused by the compiler, and it does seem correct.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
