### PR TITLE
Merge ByteArrayComparers

### DIFF
--- a/src/Address.cs
+++ b/src/Address.cs
@@ -43,7 +43,7 @@ namespace SpacetimeDB
         public static Address? From(byte[] bytes)
         {
             if (bytes.All(b => b == 0)) {
-              return null; 
+              return null;
             }
             return new Address
             {
@@ -51,15 +51,9 @@ namespace SpacetimeDB
             };
         }
 
-        public bool Equals(Address other)
-        {
-            return bytes.SequenceEqual(other.bytes);
-        }
+        public bool Equals(Address other) => ByteArrayComparer.Instance.Equals(bytes, other.bytes);
 
-        public override bool Equals(object o)
-        {
-            return o is Address other && Equals(other);
-        }
+        public override bool Equals(object o) => o is Address other && Equals(other);
 
         public static bool operator ==(Address a, Address b) => a.Equals(b);
         public static bool operator !=(Address a, Address b) => !a.Equals(b);
@@ -71,15 +65,7 @@ namespace SpacetimeDB
             return new Address{ bytes = bytes, };
         }
 
-        public override int GetHashCode()
-        {
-            if (bytes == null)
-            {
-                throw new InvalidOperationException("Cannot hash on null bytes.");
-            }
-
-            return BitConverter.ToInt32(bytes, 0);
-        }
+        public override int GetHashCode() => ByteArrayComparer.Instance.GetHashCode(bytes);
 
         public override string ToString()
         {

--- a/src/ClientCache.cs
+++ b/src/ClientCache.cs
@@ -12,49 +12,6 @@ namespace SpacetimeDB
     {
         public class TableCache
         {
-            public class ByteArrayComparer : IEqualityComparer<byte[]>
-            {
-                public bool Equals(byte[] left, byte[] right)
-                {
-                    if (ReferenceEquals(left, right))
-                    {
-                        return true;
-                    }
-
-                    if (left == null || right == null || left.Length != right.Length)
-                    {
-                        return false;
-                    }
-
-                    return EqualsUnvectorized(left, right);
-
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                private bool EqualsUnvectorized(byte[] left, byte[] right)
-                {
-                    for (int i = 0; i < left.Length; i++)
-                    {
-                        if (left[i] != right[i])
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
-                }
-
-                public int GetHashCode(byte[] obj)
-                {
-                    int hash = 17;
-                    foreach (byte b in obj)
-                    {
-                        hash = hash * 31 + b;
-                    }
-                    return hash;
-                }
-            }
-
             private readonly string name;
             private readonly Type clientTableType;
             private readonly AlgebraicType rowSchema;
@@ -138,7 +95,7 @@ namespace SpacetimeDB
                 {
                     return false;
                 }
-               
+
                 // Insert the row into our table
                 entries[rowBytes] = (value, decoderFunc(value));
                 return true;
@@ -260,7 +217,7 @@ namespace SpacetimeDB
         }
 
         public IEnumerable<string> GetTableNames() => tables.Keys;
-        
+
         public IEnumerable<TableCache> GetTables() => tables.Values;
     }
 }

--- a/src/Identity.cs
+++ b/src/Identity.cs
@@ -48,28 +48,14 @@ namespace SpacetimeDB
             };
         }
 
-        public bool Equals(Identity other)
-        {
-            return bytes.SequenceEqual(other.bytes);
-        }
+        public bool Equals(Identity other) => ByteArrayComparer.Instance.Equals(bytes, other.bytes);
 
-        public override bool Equals(object o)
-        {
-            return o is Identity other && Equals(other);
-        }
+        public override bool Equals(object o) => o is Identity other && Equals(other);
 
         public static bool operator ==(Identity a, Identity b) => a.Equals(b);
         public static bool operator !=(Identity a, Identity b) => !a.Equals(b);
 
-        public override int GetHashCode()
-        {
-            if (bytes == null)
-            {
-                throw new InvalidOperationException("Cannot hash on null bytes.");
-            }
-
-            return BitConverter.ToInt32(bytes, 0);
-        }
+        public override int GetHashCode() => ByteArrayComparer.Instance.GetHashCode(bytes);
 
         public override string ToString()
         {

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -313,7 +313,7 @@ namespace SpacetimeDB
                 {
                     if (!subscriptionInserts.TryGetValue(tableName, out var hashSet))
                     {
-                        hashSet = new HashSet<byte[]>(capacity:tableSize, comparer: new ClientCache.TableCache.ByteArrayComparer());
+                        hashSet = new HashSet<byte[]>(capacity:tableSize, comparer: new ByteArrayComparer());
                         subscriptionInserts[tableName] = hashSet;
                     }
 

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -1,44 +1,51 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 
 namespace SpacetimeDB
 {
-    public static class Utils
+    internal readonly struct ByteArrayComparer : IEqualityComparer<byte[]>
     {
-        public static bool ByteArrayCompare(byte[] a1, byte[] a2)
+        public static readonly ByteArrayComparer Instance = new();
+
+        public bool Equals(byte[]? left, byte[]? right)
         {
-            if (a1 == null || a2 == null)
-                return a1 == a2;
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
 
-            if (a1.Length != a2.Length)
+            if (left is null || right is null || left.Length != right.Length)
+            {
                 return false;
+            }
 
-            for (int i = 0; i < a1.Length; i++)
-                if (a1[i] != a2[i])
+            return EqualsUnvectorized(left, right);
+
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool EqualsUnvectorized(byte[] left, byte[] right)
+        {
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (left[i] != right[i])
+                {
                     return false;
+                }
+            }
 
             return true;
-        }
-    }
-
-    public class ByteArrayComparer : IEqualityComparer<byte[]>
-    {
-        public bool Equals(byte[] x, byte[] y)
-        {
-            return Utils.ByteArrayCompare(x, y);
         }
 
         public int GetHashCode(byte[] obj)
         {
-            if (obj == null)
-                return 0;
-            int sum = 0;
-            for (int i = 0; i < obj.Length; i++)
-                sum += obj[i];
-            return sum;
+            int hash = 17;
+            foreach (byte b in obj)
+            {
+                hash = hash * 31 + b;
+            }
+            return hash;
         }
     }
 }


### PR DESCRIPTION
## Description of Changes

There were couple of mismatched implementations of byte array comparison / hashing. This PR simply keeps the most efficient one as a utility and forwards all the usages to it.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
