### PR TITLE
Set language version to 9

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>9</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>SpacetimeDB.ClientSDK</PackageId>

--- a/src/AuthToken.cs
+++ b/src/AuthToken.cs
@@ -1,5 +1,5 @@
 ﻿/*  This is an optional helper class to store your auth token in local storage
- *  
+ *
     Example:
 
     AuthToken.Init(".my_app_name");
@@ -7,9 +7,9 @@
     SpacetimeDBClient.CreateInstance(new ConsoleLogger());
 
     SpacetimeDBClient.instance.onIdentityReceived += (token, identity) =>
-    {    
+    {
         AuthToken.SaveToken(token);
-    
+
         ...
     };
 
@@ -18,6 +18,7 @@
 #if !UNITY_5_3_OR_NEWER
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -31,7 +32,7 @@ namespace SpacetimeDB
         /// <summary>
         /// Initializes the AuthToken class. This must be called before any other methods.
         /// </summary>
-        /// <param name="configFolder">The folder to store the config file in. Default is ".spacetime_csharp_sdk".</param> 
+        /// <param name="configFolder">The folder to store the config file in. Default is ".spacetime_csharp_sdk".</param>
         /// <param name="configFile">The name of the config file. Default is "settings.ini".</param>
         /// <param name="configRoot">The root folder to store the config file in. Default is the user's home directory.</param>
         /// </summary>
@@ -67,7 +68,7 @@ namespace SpacetimeDB
         /// <summary>
         /// This is the auth token that was saved to local storage. Null if not never saved.
         /// When you specify null to the SpacetimeDBClient, SpacetimeDB will generate a new identity for you.
-        /// </summary>  
+        /// </summary>
         public static string? Token
         {
             get
@@ -79,7 +80,7 @@ namespace SpacetimeDB
                 return token;
             }
         }
-        
+
         /// <summary>
         /// Save the auth token to local storage.
         /// SpacetimeDBClient provides this token to you in the onIdentityReceived callback.


### PR DESCRIPTION
## Description of Changes

C# 9 is the last C# version supported by Unity.

While this PR doesn't require almost any C# code changes, I found that limiting the version is helpful for ensuring that I don't accidentally introduce Unity-incompatible code in larger PRs.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
