### PR TITLE
Bump version for release v0.9

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/spacetimedb-csharp-sdk</RepositoryUrl>
     <AssemblyVersion>0.8.0</AssemblyVersion>
-    <Version>0.8.0</Version>
+    <Version>0.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description of Changes

Bumped the version number to 0.9.0 as this was forgotten in the previous release. Includes all changes to date.

## API

 - [X] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

Not sure but its going out with the latest release. The previous package was 5 months ago.

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
