### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/spacetimedb-csharp-sdk</RepositoryUrl>
     <AssemblyVersion>0.8.0</AssemblyVersion>
-    <Version>0.9.0</Version>
+    <Version>0.9.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description of Changes
Just bumps the version number. Since 0.9.1 has been released, we are now on 0.9.2+!

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
