### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -17,8 +17,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/spacetimedb-csharp-sdk</RepositoryUrl>
-    <AssemblyVersion>0.8.0</AssemblyVersion>
-    <Version>0.9.2</Version>
+    <AssemblyVersion>0.10.0</AssemblyVersion>
+    <Version>0.10.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/quickstart/client/client.csproj
+++ b/examples/quickstart/client/client.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description of Changes
Bump `AssemblyVersion` and `Version` to 0.10.0.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
Oh boy, I don't know how to index this.
At least wait until https://github.com/clockworklabs/SpacetimeDB/pull/1352 is released.